### PR TITLE
Fix Error in Bisection Method

### DIFF
--- a/lib/root_solver.rb
+++ b/lib/root_solver.rb
@@ -96,8 +96,12 @@ module RootSolver
     end
 
     def solve
-      x1 = RootSolver::Bisection.new(@f, @low, @high, @tol, @n).solve
-      RootSolver::Newton.new(@f, x1, @tol).solve
+      begin
+        x1 = RootSolver::Bisection.new(@f, @low, @high, @tol, @n).solve
+        RootSolver::Newton.new(@f, x1, @tol).solve
+      rescue NonCrossingError
+        RootSolver::Newton.new(@f, (@low + @high)/2, @tol).solve
+      end
     end
   end
 

--- a/lib/root_solver.rb
+++ b/lib/root_solver.rb
@@ -2,7 +2,7 @@ require "root_solver/version"
 
 module RootSolver
   class Newton
-    def initialize(f, x0 = 0, tol = 0.01, n = 10, eps = 0.001)
+    def initialize(f, x0 = 0, tol = 0.01, n = 15, eps = 0.001)
       @f   = f
       @x0  = x0
       @tol = tol
@@ -14,7 +14,7 @@ module RootSolver
       y0 = f.call(x0)
       y_prime = (f.call(x0 + eps) - y0) / eps
 
-      raise NonconvergenceError.new if y_prime.abs < tol
+      raise NonconvergenceError.new if y_prime.abs < tol && y0.abs > tol 
 
       x = x0 - y0 / y_prime
       y = f.call(x)

--- a/test/root_solver_test.rb
+++ b/test/root_solver_test.rb
@@ -20,6 +20,11 @@ class RootSolverTest < Minitest::Test
     assert_in_delta 0, @bisection.new(one_rooted_function, -10, 10, 1e-3).solve, 1e-3
   end
 
+  def test_finds_root_of_shifted_one_rooted_function
+    assert_in_delta 1, @bisection_newton.new(shifted_one_rooted_function, 0, 3, 1e-3).solve, 1e-3
+    assert_in_delta 1, @bisection.new(shifted_one_rooted_function, 0, 3, 1e-3).solve, 1e-3
+  end
+
   def test_finds_root_of_two_rooted_function
     bn_solution = @bisection_newton.new(two_rooted_function, 0, 10, 1e-3).solve
     b_solution = @bisection.new(two_rooted_function, 0, 10, 1e-3).solve
@@ -52,6 +57,10 @@ class RootSolverTest < Minitest::Test
   private
     def one_rooted_function
       Proc.new { |x| x ** 2 }
+    end
+
+    def shifted_one_rooted_function
+      Proc.new { |x| (x - 1) ** 2 }
     end
 
     def two_rooted_function

--- a/test/root_solver_test.rb
+++ b/test/root_solver_test.rb
@@ -2,26 +2,49 @@ require 'test_helper'
 
 class RootSolverTest < Minitest::Test
   def setup
-    @subject = RootSolver::BisectionNewton
+    @bisection_newton = RootSolver::BisectionNewton
+    @bisection = RootSolver::Bisection
   end
 
   def test_that_it_has_a_version_number
     refute_nil ::RootSolver::VERSION
   end
 
+  def test_finds_root_with_root_as_initial_guess
+    assert_in_delta 0, @bisection_newton.new(one_rooted_function, 0, 10, 1e-3).solve, 1e-3
+    assert_in_delta 0, @bisection.new(one_rooted_function, 0, 10, 1e-3).solve, 1e-3
+  end
+
   def test_finds_root_of_one_rooted_function
-    assert_in_delta 0, @subject.new(one_rooted_function, -10, 10, 1e-3).solve, 1e-3
+    assert_in_delta 0, @bisection_newton.new(one_rooted_function, -10, 10, 1e-3).solve, 1e-3
+    assert_in_delta 0, @bisection.new(one_rooted_function, -10, 10, 1e-3).solve, 1e-3
   end
 
   def test_finds_root_of_two_rooted_function
-    solution = @subject.new(two_rooted_function, -10, 10, 1e-3).solve
+    bn_solution = @bisection_newton.new(two_rooted_function, 0, 10, 1e-3).solve
+    b_solution = @bisection.new(two_rooted_function, 0, 10, 1e-3).solve
 
-    assert_in_delta 0, two_rooted_function.call(solution), 1e-3
+    assert_in_delta 0, two_rooted_function.call(bn_solution), 1e-3
+    assert_in_delta 0, two_rooted_function.call(b_solution), 1e-3
+  end
+
+  def test_raises_for_non_crossing_high_low
+    assert_raises RootSolver::NonCrossingError do
+      @bisection_newton.new(two_rooted_function, 10, 10, 1e-3).solve
+    end
+
+    assert_raises RootSolver::NonCrossingError do
+      @bisection.new(two_rooted_function, 10, 10, 1e-3).solve
+    end
   end
 
   def test_raises_for_a_non_rooted_function
-    assert_raises RootSolver::NoRootError do
-      3.times { puts @subject.new(non_rooted_function, -100, 100, 1e-3, 50).solve }
+    assert_raises RootSolver::NonCrossingError do
+      3.times { puts @bisection_newton.new(non_rooted_function, -100, 100, 1e-3, 50).solve }
+    end
+
+    assert_raises RootSolver::NonCrossingError do
+      3.times { puts @bisection.new(non_rooted_function, -100, 100, 1e-3, 50).solve }
     end
   end
 
@@ -38,3 +61,4 @@ class RootSolverTest < Minitest::Test
       Proc.new { |x| 10 + (x ** 2) }
     end
 end
+

--- a/test/root_solver_test.rb
+++ b/test/root_solver_test.rb
@@ -34,13 +34,13 @@ class RootSolverTest < Minitest::Test
   end
 
   def test_bisection_newton_solves_for_non_crossing_high_low
-    bn_solution = @bisection_newton.new(two_rooted_function, 10, 10, 1e-3).solve
+    bn_solution = @bisection_newton.new(two_rooted_function, -10, 10, 1e-3).solve
     assert_in_delta 0, two_rooted_function.call(bn_solution), 1e-3
   end
 
   def test_raises_for_non_crossing_high_low
     assert_raises RootSolver::NonCrossingError do
-      @bisection.new(two_rooted_function, 10, 10, 1e-3).solve
+      @bisection.new(two_rooted_function, -10, 10, 1e-3).solve
     end
   end
 

--- a/test/root_solver_test.rb
+++ b/test/root_solver_test.rb
@@ -28,18 +28,19 @@ class RootSolverTest < Minitest::Test
     assert_in_delta 0, two_rooted_function.call(b_solution), 1e-3
   end
 
-  def test_raises_for_non_crossing_high_low
-    assert_raises RootSolver::NonCrossingError do
-      @bisection_newton.new(two_rooted_function, 10, 10, 1e-3).solve
-    end
+  def test_bisection_newton_solves_for_non_crossing_high_low
+    bn_solution = @bisection_newton.new(two_rooted_function, 10, 10, 1e-3).solve
+    assert_in_delta 0, two_rooted_function.call(bn_solution), 1e-3
+  end
 
+  def test_raises_for_non_crossing_high_low
     assert_raises RootSolver::NonCrossingError do
       @bisection.new(two_rooted_function, 10, 10, 1e-3).solve
     end
   end
 
   def test_raises_for_a_non_rooted_function
-    assert_raises RootSolver::NonCrossingError do
+    assert_raises RootSolver::NonconvergenceError do
       3.times { puts @bisection_newton.new(non_rooted_function, -100, 100, 1e-3, 50).solve }
     end
 


### PR DESCRIPTION
Short circuit when one of the initial guesses is a root.
Redefine halving calculation.
Raise error when f(high) and f(low) have the same sign. Initial guesses
must evaluate to have opposite signs to use the Bisection Method.